### PR TITLE
Redirect to the authorization endpoint

### DIFF
--- a/oama.cabal
+++ b/oama.cabal
@@ -18,6 +18,7 @@ common common
     directory,
     hsyslog,
     http-conduit,
+    http-types,
     mtl,
     network,
     network-uri,


### PR DESCRIPTION
Currently, when the `auth_http_method` is set to `GET`, oama fetches the page served by the endpoint and redisplays it to the user. This PR changes the behavior to instead redirect the user to the target endpoint.

In particular it fixes an issue with Microsoft authorization, because otherwise the flow gets stuck with a "contextID supplied in the request did not have a matching cookie" error. This is because the request to the auth endpoint is made by oama, and not in the browser.

I verified that my version works with Outlook personal and GMail personal, which is all I have access to.