### PR TITLE
Implement OAuth 2.0 Device Authorization Grant (RFC 8628)

### DIFF
--- a/lib/OAMa/Authorization.hs
+++ b/lib/OAMa/Authorization.hs
@@ -219,7 +219,7 @@ renewAccessToken env (Just serv) rft = do
   api <- getServiceAPI env serv
   let qs =
         [ ("client_id", Just api.client_id),
-          ("client_secret", Just api.client_secret),
+          ("client_secret", api.client_secret),
           ("grant_type", Just "refresh_token"),
           ("refresh_token", rft)
         ]
@@ -296,7 +296,7 @@ getAccessToken env serv redirectURI authcode = do
   api <- getServiceAPI env serv
   let qs =
         [ ("client_id", Just api.client_id),
-          ("client_secret", Just api.client_secret),
+          ("client_secret", api.client_secret),
           ("code", Just authcode),
           ("grant_type", Just "authorization_code"),
           ("tenant", api.tenant),

--- a/lib/OAMa/Environment.hs
+++ b/lib/OAMa/Environment.hs
@@ -10,6 +10,7 @@
 module OAMa.Environment
   ( AuthRecord (..),
     AuthError (..),
+    DeviceAuthResponse (device_code, user_code, verification_uri, verification_uri_complete, interval),
     Configuration (..),
     Environment (..),
     ServiceAPI (..),
@@ -167,11 +168,22 @@ data AuthRecord = AuthRecord
   }
   deriving (Show, Generic, Yaml.ToJSON, Yaml.FromJSON)
 
-data AuthError = InvalidRequest | UnauthorizedClient | AccessDenied | UnsupportedResponseType | InvalidScope | ServerError | TemporarilyUnavailable | Unknown String
+data AuthError = InvalidRequest | UnauthorizedClient | AccessDenied | UnsupportedResponseType | InvalidScope | ServerError | TemporarilyUnavailable | AuthorizationPending | SlowDown | ExpiredToken | Unknown String
   deriving (Show, Generic)
 
 instance Yaml.FromJSON AuthError where
   parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = False, sumEncoding = TaggedObject "error" "raw"}
+
+data DeviceAuthResponse = DeviceAuthResponse
+  { device_code :: String,
+    user_code :: String,
+    verification_uri :: String,
+    verification_uri_complete :: Maybe String,
+    expires_in :: NominalDiffTime,
+    interval :: Maybe Int
+  }
+  deriving (Show, Generic, Yaml.FromJSON)
+
 -- |
 -- Update defaultServiceAPI with the values read from the config file. Merge fields
 -- of Maybe type with Applicative.(<|>) (short circuting on config values), for

--- a/lib/OAMa/Environment.hs
+++ b/lib/OAMa/Environment.hs
@@ -9,6 +9,7 @@
 
 module OAMa.Environment
   ( AuthRecord (..),
+    AuthError (..),
     Configuration (..),
     Environment (..),
     ServiceAPI (..),
@@ -28,6 +29,7 @@ where
 import Control.Applicative ((<|>))
 import Control.Monad (when)
 import Crypto.Manager (secretMethod)
+import Data.Aeson.Types (Options (allNullaryToStringTag, constructorTagModifier, sumEncoding), SumEncoding (..), camelTo2, defaultOptions, genericParseJSON)
 import Data.ByteString.UTF8 qualified as BSU
 import Data.Map (Map)
 import Data.Map.Strict qualified as Map
@@ -165,6 +167,11 @@ data AuthRecord = AuthRecord
   }
   deriving (Show, Generic, Yaml.ToJSON, Yaml.FromJSON)
 
+data AuthError = InvalidRequest | UnauthorizedClient | AccessDenied | UnsupportedResponseType | InvalidScope | ServerError | TemporarilyUnavailable | Unknown String
+  deriving (Show, Generic)
+
+instance Yaml.FromJSON AuthError where
+  parseJSON = genericParseJSON defaultOptions {constructorTagModifier = camelTo2 '_', allNullaryToStringTag = False, sumEncoding = TaggedObject "error" "raw"}
 -- |
 -- Update defaultServiceAPI with the values read from the config file. Merge fields
 -- of Maybe type with Applicative.(<|>) (short circuting on config values), for

--- a/lib/OAMa/Environment.hs
+++ b/lib/OAMa/Environment.hs
@@ -72,7 +72,7 @@ data ServiceAPI = ServiceAPI
     access_type :: Maybe String,
     prompt :: Maybe String,
     client_id :: String,
-    client_secret :: String
+    client_secret :: Maybe String
   }
   deriving (Show, Generic, Yaml.ToJSON, Yaml.FromJSON)
 
@@ -94,7 +94,7 @@ defaultServiceAPI =
       access_type = Nothing,
       prompt = Nothing,
       client_id = "application-CLIENT-ID",
-      client_secret = "application-CLIENT-SECRET"
+      client_secret = Just "application-CLIENT-SECRET"
     }
 
 type Services = Map String ServiceAPI
@@ -110,7 +110,7 @@ builtinServices =
             access_type = Just "offline",
             prompt = Just "consent",
             client_id = "application-CLIENT-ID",
-            client_secret = "application-CLIENT-SECRET"
+            client_secret = Just "application-CLIENT-SECRET"
           }
       ),
       ( "microsoft",
@@ -124,7 +124,7 @@ builtinServices =
                 "https://outlook.office.com/IMAP.AccessAsUser.All https://outlook.office.com/POP.AccessAsUser.All https://outlook.office.com/SMTP.Send offline_access",
             tenant = Just "common",
             client_id = "application-CLIENT-ID",
-            client_secret = "application-CLIENT-SECRET"
+            client_secret = Just "application-CLIENT-SECRET"
           }
       )
     ]


### PR DESCRIPTION
It seems like it's a bit too restrictive to use the `client_secret` in the standard OAuth authorization code flow with a `localhost` redirect URI, especially on Microsoft services.
Many users of corporate Microsoft accounts (for me, in a university setting) do not have the capability to register an OAuth application to their tenant, and it seems like this is affecting even personal Outlook accounts now (#73).

This PR addresses this by implementing the alternative OAuth device code flow, whereby the user has to manually input an authorization code when logging in, i.e.:

```
Visit:
https://microsoft.com/devicelogin

and enter the code:
AA8DVLGU8
```

For example, Mozilla Thunderbird uses this flow to authenticate OAuth accounts now also.

Example working config excerpt:
```yaml
services:
  microsoft:
    auth_endpoint: https://login.microsoftonline.com/common/oauth2/v2.0/devicecode
    client_id: 9e5f94bc-e8a4-4e73-b8be-63364c29d753
    tenant: common
```

Related issues: #73 #74 #41 