### PR TITLE
Hint at higher required ghc version in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Additionally to this GitHub repository the source code is also mirrored at
 [Sourcehut](https://git.sr.ht/~petrus/oama).
 
 To build `oama` from source you need a Haskell development environment,
-with `ghc 9.8.x` or higher. Either your platform's package system can provide
+with `ghc 9.12.x` or higher. Either your platform's package system can provide
 this or you can use [ghcup](https://www.haskell.org/ghcup/).
 
 There is a `justfile` for building using the


### PR DESCRIPTION
MultilineStrings extension is supported with ghc version 9.12.1+

(I am a complete beginner with haskell/ghc, so I might have gotten something wrong.)